### PR TITLE
allow usage of particular output stream

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -154,3 +154,6 @@ $RECYCLE.BIN/
 
 # Mac desktop service store files
 .DS_Store
+main.o
+progress_bar.o
+progress_bar

--- a/progress_bar.cpp
+++ b/progress_bar.cpp
@@ -94,7 +94,7 @@ void ProgressBar::Progressed(unsigned long idx_)
             }
         }
 
-        *out << "]" << std::setw(CHARACTER_WIDTH_PERCENTAGE) << std::setprecision(3) << progress_percent << "%\r" << std::flush;
+        *out << "]" << std::setw(CHARACTER_WIDTH_PERCENTAGE + 1) << std::setprecision(1) << std::fixed << progress_percent << "%\r" << std::flush;
     }
     catch(unsigned long e){
         ClearBarField();

--- a/progress_bar.cpp
+++ b/progress_bar.cpp
@@ -1,30 +1,18 @@
-#ifdef _WINDOWS
-#include <windows.h>
-#else
-#include <sys/ioctl.h>
-#endif
-
-#include <iostream>
-#include <iomanip>
-#include <cstring>
-
 #include "progress_bar.hpp"
 
-#define TOTAL_PERCENTAGE 100.0
-#define CHARACTER_WIDTH_PERCENTAGE 4
+ProgressBar::ProgressBar() {}
 
-ProgressBar::ProgressBar(){}
-
-ProgressBar::ProgressBar(unsigned long n_, const char* description_){
+ProgressBar::ProgressBar(unsigned long n_, const char* description_, std::ostream& out_){
     
     n = n_;
     frequency_update = n_;
     description = description_;
+    out = &out_;
 	
 	unit_bar = "=";
 	unit_space = " ";
 	desc_width = std::strlen(description);	// character width of description field
-	
+
 }
 
 void ProgressBar::SetFrequencyUpdate(unsigned long frequency_update_){
@@ -72,9 +60,9 @@ int ProgressBar::GetBarLength(){
 void ProgressBar::ClearBarField(){
 
     for(int i=0;i<GetConsoleWidth();++i){
-        std::cout << " ";
+        *out << " ";
     }
-    std::cout << "\r" << std::flush;
+    *out << "\r" << std::flush;
 }
 
 void ProgressBar::Progressed(unsigned long idx_)
@@ -95,18 +83,18 @@ void ProgressBar::Progressed(unsigned long idx_)
         double percent_per_unit_bar = TOTAL_PERCENTAGE/bar_size;
 
         // display progress bar
-	    std::cout << " " << description << " [";
+	    *out << " " << description << " [";
 
         for(int bar_length=0;bar_length<=bar_size-1;++bar_length){
             if(bar_length*percent_per_unit_bar<progress_percent){
-                std::cout << unit_bar;
+                *out << unit_bar;
             }
             else{
-                std::cout << unit_space;
+                *out << unit_space;
             }
         }
 
-        std::cout << "]" << std::setw(CHARACTER_WIDTH_PERCENTAGE) << static_cast<int>(progress_percent) << "%\r" << std::flush;
+        *out << "]" << std::setw(CHARACTER_WIDTH_PERCENTAGE) << static_cast<int>(progress_percent) << "%\r" << std::flush;
     }
     catch(unsigned long e){
         ClearBarField();

--- a/progress_bar.cpp
+++ b/progress_bar.cpp
@@ -15,7 +15,7 @@
 
 ProgressBar::ProgressBar(){}
 
-ProgressBar::ProgressBar(unsigned int n_, const char* description_){
+ProgressBar::ProgressBar(unsigned long n_, const char* description_){
     
     n = n_;
     frequency_update = n_;
@@ -27,7 +27,7 @@ ProgressBar::ProgressBar(unsigned int n_, const char* description_){
 	
 }
 
-void ProgressBar::SetFrequencyUpdate(unsigned int frequency_update_){
+void ProgressBar::SetFrequencyUpdate(unsigned long frequency_update_){
 	
 	if(frequency_update_ > n){
 		frequency_update = n;	 // prevents crash if freq_updates_ > n_
@@ -77,7 +77,7 @@ void ProgressBar::ClearBarField(){
     std::cout << "\r" << std::flush;
 }
 
-void ProgressBar::Progressed(unsigned int idx_)
+void ProgressBar::Progressed(unsigned long idx_)
 {
     try{
         if(idx_ > n) throw idx_;
@@ -108,9 +108,9 @@ void ProgressBar::Progressed(unsigned int idx_)
 
         std::cout << "]" << std::setw(CHARACTER_WIDTH_PERCENTAGE) << static_cast<int>(progress_percent) << "%\r" << std::flush;
     }
-    catch(unsigned int e){
+    catch(unsigned long e){
         ClearBarField();
-        std::cerr << "PROGRESS_BAR_EXCEPTION: _idx (" << e << ") went out of bounds, greater than n (" << n << ").\r" << std::flush;
+        std::cerr << "PROGRESS_BAR_EXCEPTION: _idx (" << e << ") went out of bounds, greater than n (" << n << ")." << std::endl << std::flush;
     }
 
 }

--- a/progress_bar.cpp
+++ b/progress_bar.cpp
@@ -94,7 +94,7 @@ void ProgressBar::Progressed(unsigned long idx_)
             }
         }
 
-        *out << "]" << std::setw(CHARACTER_WIDTH_PERCENTAGE) << static_cast<int>(progress_percent) << "%\r" << std::flush;
+        *out << "]" << std::setw(CHARACTER_WIDTH_PERCENTAGE) << std::setprecision(3) << progress_percent << "%\r" << std::flush;
     }
     catch(unsigned long e){
         ClearBarField();

--- a/progress_bar.hpp
+++ b/progress_bar.hpp
@@ -5,18 +5,18 @@ class ProgressBar{
 
     public:        
         ProgressBar();
-        ProgressBar(unsigned int n_, const char *description_="");
+        ProgressBar(unsigned long n_, const char *description_="");
 		
-		void SetFrequencyUpdate(unsigned int frequency_update_);
+		void SetFrequencyUpdate(unsigned long frequency_update_);
 		void SetStyle(const char* unit_bar_, const char* unit_space_);		
 
-        void Progressed(unsigned int idx_);
+        void Progressed(unsigned long idx_);
 		
     private:
 	
-		unsigned int n;
+		unsigned long n;
 		unsigned int desc_width;
-		unsigned int frequency_update;
+		unsigned long frequency_update;
 		
 		const char *description;
 		const char *unit_bar;

--- a/progress_bar.hpp
+++ b/progress_bar.hpp
@@ -1,30 +1,45 @@
 #ifndef _PROGRESS_BAR_
 #define _PROGRESS_BAR_
 
+#ifdef _WINDOWS
+#include <windows.h>
+#else
+#include <sys/ioctl.h>
+#endif
+
+#include <iostream>
+#include <iomanip>
+#include <cstring>
+
+#define TOTAL_PERCENTAGE 100.0
+#define CHARACTER_WIDTH_PERCENTAGE 4
+
 class ProgressBar{
 
-    public:        
-        ProgressBar();
-        ProgressBar(unsigned long n_, const char *description_="");
-		
-		void SetFrequencyUpdate(unsigned long frequency_update_);
-		void SetStyle(const char* unit_bar_, const char* unit_space_);		
+public: 
 
-        void Progressed(unsigned long idx_);
-		
-    private:
+    ProgressBar();
+    ProgressBar(unsigned long n_, const char *description_="", std::ostream& out_=std::cerr);
+
+    void SetFrequencyUpdate(unsigned long frequency_update_);
+    void SetStyle(const char* unit_bar_, const char* unit_space_);		
+
+    void Progressed(unsigned long idx_);
+
+private:
 	
-		unsigned long n;
-		unsigned int desc_width;
-		unsigned long frequency_update;
+    unsigned long n;
+    unsigned int desc_width;
+    unsigned long frequency_update;
+    std::ostream* out;
 		
-		const char *description;
-		const char *unit_bar;
-        const char *unit_space;
+    const char *description;
+    const char *unit_bar;
+    const char *unit_space;
 		
-		void ClearBarField();
-		int GetConsoleWidth();
-		int GetBarLength();
+    void ClearBarField();
+    int GetConsoleWidth();
+    int GetBarLength();
 
 };
 


### PR DESCRIPTION
In applications that provide results on stdout, it is necessary to allow writing to an alternative output stream. This allows that functionality.
